### PR TITLE
Fix Activities localization failure

### DIFF
--- a/RPAStudio/Activities/RPA.Core.Activities/RPA.Core.Activities.nuspec
+++ b/RPAStudio/Activities/RPA.Core.Activities/RPA.Core.Activities.nuspec
@@ -15,6 +15,6 @@
     <tags>RPA Core Activity</tags>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.*" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
+    <file src="bin\$configuration$\**" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
   </files>
 </package>

--- a/RPAStudio/Activities/RPA.Integration.Activities/RPA.Integration.Activities.nuspec
+++ b/RPAStudio/Activities/RPA.Integration.Activities/RPA.Integration.Activities.nuspec
@@ -15,6 +15,6 @@
     <tags>RPA Integration Activity</tags>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.*" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
+    <file src="bin\$configuration$\**" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
   </files>
 </package>

--- a/RPAStudio/Activities/RPA.Script.Activities/RPA.Script.Activities.nuspec
+++ b/RPAStudio/Activities/RPA.Script.Activities/RPA.Script.Activities.nuspec
@@ -15,6 +15,6 @@
     <tags>RPA Script Activity</tags> 
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.*" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
+    <file src="bin\$configuration$\**" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
   </files>
 </package>

--- a/RPAStudio/Activities/RPA.UIAutomation.Activities/Properties/Resources.en-US.resx
+++ b/RPAStudio/Activities/RPA.UIAutomation.Activities/Properties/Resources.en-US.resx
@@ -121,7 +121,7 @@
     <value>Public</value>
   </data>
   <data name="DisplayName1" xml:space="preserve">
-    <value>Error execution</value>
+    <value>Error Execution</value>
   </data>
   <data name="Description1" xml:space="preserve">
     <value>Specifies whether automation should continue even if the activity raises an error</value>
@@ -199,7 +199,7 @@
     <value>The name of the property to wait for.  A predefined list of attributes can be used as a drop-down list in the activity.  This field only supports String variables.</value>
   </data>
   <data name="DisplayName10" xml:space="preserve">
-    <value>Attribute value</value>
+    <value>Attribute Value</value>
   </data>
   <data name="Description13" xml:space="preserve">
     <value>Specifies the expected value of the attribute.  This field only supports String variables.</value>
@@ -238,13 +238,13 @@
     <value>The browser page to close.  This field only supports the Browser variable.</value>
   </data>
   <data name="DisplayName17" xml:space="preserve">
-    <value>Delay time (end)</value>
+    <value>Delay Time (End)</value>
   </data>
   <data name="Description19" xml:space="preserve">
     <value>The delay (in milliseconds) after the activity is executed. The default time is 3000 milliseconds.</value>
   </data>
   <data name="DisplayName18" xml:space="preserve">
-    <value>Delay time (start)</value>
+    <value>Delay Time (Start)</value>
   </data>
   <data name="Description20" xml:space="preserve">
     <value>The delay (in milliseconds) before the activity begins any operation, the default amount of time is 3000 milliseconds.</value>
@@ -289,7 +289,7 @@
     <value>Specify browser response timeout (ms)</value>
   </data>
   <data name="DisplayName24" xml:space="preserve">
-    <value>Private/no trace</value>
+    <value>Private/No Trace</value>
   </data>
   <data name="DisplayName25" xml:space="preserve">
     <value>Hide</value>
@@ -304,7 +304,7 @@
     <value>The delay (in milliseconds) before the activity begins any operation, the default amount of time is 200 milliseconds.</value>
   </data>
   <data name="DisplayName26" xml:space="preserve">
-    <value>HTML attribute</value>
+    <value>HTML Attribute</value>
   </data>
   <data name="Description32" xml:space="preserve">
     <value>The name of the HTML attribute to change</value>
@@ -346,7 +346,7 @@
     <value>a string to write the Text property of the UI element</value>
   </data>
   <data name="DisplayName35" xml:space="preserve">
-    <value>Anchor position</value>
+    <value>Anchor Position</value>
   </data>
   <data name="Category7" xml:space="preserve">
     <value>Anchor boundary box</value>
@@ -391,7 +391,7 @@
     <value>The xml string specifies the conditions that all UI Objects in the collection should satisfy.</value>
   </data>
   <data name="DisplayName40" xml:space="preserve">
-    <value>Child element</value>
+    <value>Child Element</value>
   </data>
   <data name="Description45" xml:space="preserve">
     <value>All ui child elements will follow the set filter and scope.  This field only supports IEnumerable&lt;UIElement&gt; variables</value>
@@ -415,7 +415,7 @@
     <value>Position</value>
   </data>
   <data name="DisplayName44" xml:space="preserve">
-    <value>Relative element</value>
+    <value>Relative Element</value>
   </data>
   <data name="Description49" xml:space="preserve">
     <value>The relative ui element you are looking for.  Only UIElement type variables are supported</value>
@@ -427,7 +427,7 @@
     <value>Specify which level of the ui hierarchy to find the parent node</value>
   </data>
   <data name="DisplayName46" xml:space="preserve">
-    <value>Parent node</value>
+    <value>Parent Node</value>
   </data>
   <data name="Description51" xml:space="preserve">
     <value>The parent of the element.  Only UIElement type variables are supported</value>
@@ -451,7 +451,7 @@
     <value>The delay time, in milliseconds, before the deferred the activity is executed. The default time is 300 milliseconds.</value>
   </data>
   <data name="Category9" xml:space="preserve">
-    <value>Key options</value>
+    <value>Key Options</value>
   </data>
   <data name="DisplayName47" xml:space="preserve">
     <value>Other buttons</value>
@@ -478,7 +478,7 @@
     <value>The time (in milliseconds) before the deferred activity begins any operation.  The default time is 200 milliseconds.</value>
   </data>
   <data name="DisplayName50" xml:space="preserve">
-    <value>Specified number</value>
+    <value>Specified Number</value>
   </data>
   <data name="Description61" xml:space="preserve">
     <value>If the string in the text field appears multiple times in the specified ui element, specify the number of occurrences here instead of the number of clicks</value>
@@ -490,7 +490,7 @@
     <value>The text to click</value>
   </data>
   <data name="DisplayName51" xml:space="preserve">
-    <value>Waiting time</value>
+    <value>Waiting Time</value>
   </data>
   <data name="Description64" xml:space="preserve">
     <value>The amount of time to wait for loading to the next page</value>
@@ -514,7 +514,7 @@
     <value>If checked, clicking the next link/ button for navigating to the next page will be performed by sending a specific message to the othe target application.  This input method works in the background and is compatible with most desktop applications, but it's not the fastest way</value>
   </data>
   <data name="DisplayName55" xml:space="preserve">
-    <value>Simulated click</value>
+    <value>Simulated Click</value>
   </data>
   <data name="Description68" xml:space="preserve">
     <value>If checked, it will use the technology simulation of the target application to click the next link/button used to navigate the next page.  This input method is the fastest of the three input methods and works in the background.</value>
@@ -547,13 +547,13 @@
     <value>Screen coordinates of each word found in the specified ui element</value>
   </data>
   <data name="DisplayName60" xml:space="preserve">
-    <value>Window title</value>
+    <value>Window Title</value>
   </data>
   <data name="Description74" xml:space="preserve">
     <value>Enter window title</value>
   </data>
   <data name="DisplayName61" xml:space="preserve">
-    <value>Window class name</value>
+    <value>Window Class Name</value>
   </data>
   <data name="Description75" xml:space="preserve">
     <value>Enter window class name</value>
@@ -568,7 +568,7 @@
     <value>The active window found.  This field only supports Window variables.  The SearchScope and Selector properties are ignored when the Window variable is specified.</value>
   </data>
   <data name="DisplayName63" xml:space="preserve">
-    <value>Window handle</value>
+    <value>Window Handle</value>
   </data>
   <data name="Description78" xml:space="preserve">
     <value>The window handle to close.</value>

--- a/RPAStudio/Activities/RPA.UIAutomation.Activities/Properties/Resources.ja-JP.resx
+++ b/RPAStudio/Activities/RPA.UIAutomation.Activities/Properties/Resources.ja-JP.resx
@@ -367,13 +367,13 @@
     <value>アクティビティでエラーが発生した場合でも自動化を続行するかどうかを、値（TrueまたはFalse）で指定します</value>
   </data>
   <data name="DisplayName36" xml:space="preserve">
-    <value>要素が停止するのを待っています</value>
+    <value>要素が停止するまで待つ</value>
   </data>
   <data name="Description41" xml:space="preserve">
     <value>このオプションを選択すると、アクティビティは指定されたイベントの終わりまで待機します</value>
   </data>
   <data name="DisplayName37" xml:space="preserve">
-    <value>要素が消えるのを待っています</value>
+    <value>要素が消えるまで待つ</value>
   </data>
   <data name="Description42" xml:space="preserve">
     <value>このオプションを選択すると、ui要素がまだアクティブであっても、アクティビティは画面からui要素が消えるまで待機するだけです。</value>
@@ -397,13 +397,13 @@
     <value>すべてのui子要素は、設定されたフィルターとスコープに従います。 このフィールドはIEnumerable &lt;UIElement&gt;変数のみをサポートします</value>
   </data>
   <data name="DisplayName41" xml:space="preserve">
-    <value>アクティビティを待っています</value>
+    <value>アクティビティを待つ</value>
   </data>
   <data name="Description46" xml:space="preserve">
     <value>このオプションを選択すると、アクティビティは指定されたui要素がアクティブになるのを待ちます。</value>
   </data>
   <data name="DisplayName42" xml:space="preserve">
-    <value>見えるまで待っています</value>
+    <value>見えるまで待つ</value>
   </data>
   <data name="Description47" xml:space="preserve">
     <value>このオプションを選択すると、アクティビティは指定されたui要素が表示されるまで待機します。</value>
@@ -469,7 +469,7 @@
     <value>UIAutomationInfoを入力します</value>
   </data>
   <data name="DisplayName49" xml:space="preserve">
-    <value>ひも</value>
+    <value>String</value>
   </data>
   <data name="Description59" xml:space="preserve">
     <value>クリックする文字列</value>
@@ -559,7 +559,7 @@
     <value>Windowのクラス名を入力</value>
   </data>
   <data name="DisplayName62" xml:space="preserve">
-    <value>窓</value>
+    <value>Window</value>
   </data>
   <data name="Description76" xml:space="preserve">
     <value>ウィンドウを格納する変数。 このフィールドはウィンドウ変数のみを受け入れます</value>
@@ -574,7 +574,7 @@
     <value>閉じるウィンドウハンドル。</value>
   </data>
   <data name="DisplayName64" xml:space="preserve">
-    <value>身長</value>
+    <value>高さ</value>
   </data>
   <data name="Description79" xml:space="preserve">
     <value>正および負の整数をサポートするウィンドウの新しい高さ</value>
@@ -586,7 +586,7 @@
     <value>正および負の整数をサポートするウィンドウの新しい幅</value>
   </data>
   <data name="DisplayName66" xml:space="preserve">
-    <value>座標X</value>
+    <value>X座標</value>
   </data>
   <data name="Description81" xml:space="preserve">
     <value>ウィンドウの新しい位置座標はX軸であり、正および負の整数をサポートします</value>

--- a/RPAStudio/Activities/RPA.UIAutomation.Activities/RPA.UIAutomation.Activities.nuspec
+++ b/RPAStudio/Activities/RPA.UIAutomation.Activities/RPA.UIAutomation.Activities.nuspec
@@ -15,6 +15,6 @@
     <tags>RPA UIAutomation Activity</tags>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.*" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
+    <file src="bin\$configuration$\**" target="lib/net452" exclude="bin\$configuration$\*.pdb;bin\$configuration$\$id$.dll;bin\$configuration$\$id$.dll.config" />
   </files>
 </package>


### PR DESCRIPTION
1) Localized dlls of Extended.WPF.Toolkit are not included in Activity's nuget package.
 -> Fix .nuspec file in each Activities.
2) Nuget loading problem. If it fails to load a nuget package, fails to load localized version of Activities.
 -> Tighten the try-catch scope at GetPackageDependencies.
3) Some localization fixes 